### PR TITLE
Add in "UseIncreasedWindSpeed" config to allow the user to make millwright windmills mimic vanilla windmill behavior/balance

### DIFF
--- a/ModConfig/ModConfig.cs
+++ b/ModConfig/ModConfig.cs
@@ -5,6 +5,7 @@ namespace Millwright.ModConfig
         public static ModConfig Loaded { get; set; } = new ModConfig();
 
         public bool AllowSailDeconstruction { get; set; } = true;
+        public bool UseIncreasedWindSpeed { get; set; } = true;
         public double BrakeResistanceModifier { get; set; } = 2.0;
         public double SailCenteredModifier { get; set; } = 2.0;
         public double SailAngledModifier { get; set; } = 2.0;

--- a/ModSystem/bebehavior/bebehaviorwindmillrotorenhanced.cs
+++ b/ModSystem/bebehavior/bebehaviorwindmillrotorenhanced.cs
@@ -32,6 +32,7 @@ namespace Millwright.ModSystem
         private readonly float angledbladeModifier = (float)ModConfig.Loaded.SailAngledModifier;
         private readonly float widebladeModifier = (float)ModConfig.Loaded.SailWideModifier;
         private readonly float sailRotationModifier = (float)ModConfig.Loaded.SailRotationModifier;
+        private readonly bool useIncreasedWindSpeed = ModConfig.Loaded.UseIncreasedWindSpeed;
 
         public float bladeModifier = 1.0f;
 
@@ -39,9 +40,9 @@ namespace Millwright.ModSystem
 
 
 
-        protected override double AccelerationFactor => 0.05d + (this.bladeModifier / 4); // 1.2.3
+        protected override double AccelerationFactor => useIncreasedWindSpeed ? 0.05d + (this.bladeModifier / 4) : 0.05d; // 1.2.3
 
-        protected override float TargetSpeed => (float)Math.Min(0.6f * this.bladeModifier, this.windSpeed * this.bladeModifier); // 1.2.3
+        protected override float TargetSpeed => useIncreasedWindSpeed ? (float)Math.Min(0.6f * this.bladeModifier, this.windSpeed * this.bladeModifier) : (float)Math.Min(0.6f, this.windSpeed); // 1.2.3
 
         protected override float TorqueFactor => this.SailLength * this.bladeModifier / 4f;  // 1.2.3
 

--- a/ModSystem/bebehavior/bebehaviorwindmillrotorud.cs
+++ b/ModSystem/bebehavior/bebehaviorwindmillrotorud.cs
@@ -30,13 +30,14 @@ namespace Millwright.ModSystem
 
         private readonly float widebladeModifier = (float)ModConfig.Loaded.SailWideModifier;
         private readonly float sailRotationModifier = (float)ModConfig.Loaded.SailRotationModifier;
+        private readonly bool useIncreasedWindSpeed = ModConfig.Loaded.UseIncreasedWindSpeed;
 
         public float bladeModifier = 1.0f;
 
         protected override float Resistance => 0.003f;
-        protected override double AccelerationFactor => 0.05d + (this.bladeModifier / 4);
+        protected override double AccelerationFactor => useIncreasedWindSpeed ? 0.05d + (this.bladeModifier / 4) : 0.05d;
 
-        protected override float TargetSpeed => (float)Math.Min(0.6f * this.bladeModifier, this.windSpeed * this.bladeModifier);
+        protected override float TargetSpeed => useIncreasedWindSpeed ? (float)Math.Min(0.6f * this.bladeModifier, this.windSpeed * this.bladeModifier) : (float)Math.Min(0.6f, this.windSpeed);
 
         protected override float TorqueFactor => this.SailLength * this.bladeModifier / 4f;    // Should stay at /4f (5 sails are supposed to have "125% power output")
 


### PR DESCRIPTION
Relates to https://github.com/SpearAndFang/millwright/issues/3

I added in a config here that just makes the millwright windmills mimic the vanilla acceleration and wind speeds. This allows you to still have the cool visual look of the millwright windmills and higher windmill density with the eight sail windmill, but doesn't give you insanely high base wind speeds that can break vanilla balance (since you get an exceptionally high speed that you can only get from gearing up in vanilla, without paying for the 5.5x torque cost for gearing up in the first place). The config defaults to the current behavior by default so it doesn't suprise anyone, but the user can turn off the increased wind speed if they wish.