### PR TITLE
Group patched recipes by ingredients

### DIFF
--- a/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotor-oils.json
@@ -11,7 +11,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -72,7 +72,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -133,7 +133,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -194,7 +194,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotor.json
+++ b/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotor.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -62,7 +62,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -118,7 +118,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -169,7 +169,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -220,7 +220,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -272,7 +272,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -328,7 +328,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -379,7 +379,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -430,7 +430,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -481,7 +481,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotorud.json
+++ b/assets/millwright/patches/floralzonescaperegion/recipes/grid/windmillrotorud.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,MCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 2,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotor-oils.json
@@ -11,7 +11,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -72,7 +72,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotor.json
+++ b/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotor.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -62,7 +62,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -118,7 +118,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -169,7 +169,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -220,7 +220,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotorud.json
+++ b/assets/millwright/patches/floralzonescaribbeanregion/recipes/grid/windmillrotorud.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,MCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 2,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotor-oils.json
@@ -11,7 +11,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -72,7 +72,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotor.json
+++ b/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotor.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -62,7 +62,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -118,7 +118,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -169,7 +169,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -220,7 +220,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotorud.json
+++ b/assets/millwright/patches/floralzonescentralaustralianregion/recipes/grid/windmillrotorud.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,MCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 2,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotor-oils.json
@@ -11,7 +11,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -72,7 +72,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotor.json
+++ b/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotor.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -62,7 +62,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -118,7 +118,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -169,7 +169,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -220,7 +220,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotorud.json
+++ b/assets/millwright/patches/floralzonesmediterraneanregion/recipes/grid/windmillrotorud.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,MCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 2,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotor-oils.json
@@ -11,7 +11,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -72,7 +72,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -133,7 +133,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -194,7 +194,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotor.json
+++ b/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotor.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -62,7 +62,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -118,7 +118,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -169,7 +169,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -220,7 +220,7 @@
 			"ingredientPattern": "HCS,RLE",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -272,7 +272,7 @@
 			"ingredientPattern": "HCS,RLE,M__",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -328,7 +328,7 @@
 			"ingredientPattern": "_H_,_CM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -379,7 +379,7 @@
 			"ingredientPattern": "_H_,LCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -430,7 +430,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -481,7 +481,7 @@
 			"ingredientPattern": "_H_,MC_,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotorud.json
+++ b/assets/millwright/patches/floralzonesneozeylandicregion/recipes/grid/windmillrotorud.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,MCM,ELF",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 2,
+			"recipegroup": 1,
 			"ingredients": {
 				"H": {
 					"type": "item",

--- a/assets/millwright/patches/oils/recipes/grid/windmillrotor-oils.json
+++ b/assets/millwright/patches/oils/recipes/grid/windmillrotor-oils.json
@@ -10,7 +10,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -70,7 +70,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -130,7 +130,7 @@
 			"ingredientPattern": "_H_,_CM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",
@@ -190,7 +190,7 @@
 			"ingredientPattern": "_H_,LCM,ELO",
 			"enabled": true,
 			"shapeless": false,
-			"recipegroup": 3,
+			"recipegroup": 2,
 			"ingredients": {
 				"H": {
 					"type": "item",


### PR DESCRIPTION
This updates the recipes added by compatibility patches to also be grouped based on the ingredients and ingredient pattern. Previously all patched recipes were grouped together, regardless of ingredient substitution or pattern changes, making the last recipe group feel cluttered and difficult to determine the options available.